### PR TITLE
Links to external sites use #+LINK instead of #+TARGET

### DIFF
--- a/000-intro.org
+++ b/000-intro.org
@@ -41,5 +41,5 @@ fall in the trap of the 2nd, eternally.
   challenge yourself getting your hands dirty.
 
 
-#+TARGET: doom https://github.com/doomemacs/
-#+TARGET: spacemacs https://www.spacemacs.org/
+#+LINK: doom https://github.com/doomemacs/
+#+LINK: spacemacs https://www.spacemacs.org/

--- a/002-use-package.org
+++ b/002-use-package.org
@@ -92,4 +92,4 @@ its functionalities reading its documentation. But take your time:
 you just started the journey and Emacs is going to accompany you
 forever.
 
-#+TARGET: vertico https://github.com/minad/vertico
+#+LINK: vertico https://github.com/minad/vertico

--- a/003-which-key.org
+++ b/003-which-key.org
@@ -67,4 +67,4 @@ read. But you have no need to rush: the girl with kaleidoscope eyes is
 infinitely understanding and patient. Take your time and enjoy the ride.
 
 
-#+TARGET: which-key https://github.com/justbur/emacs-which-key
+#+LINK: which-key https://github.com/justbur/emacs-which-key

--- a/005-jump.org
+++ b/005-jump.org
@@ -56,4 +56,4 @@ teach you this just yet! Just don't feel compelled to close files.
 
 Instead, keep on jumping...
 
-#+TARGET: consult https://github.com/minad/consult
+#+LINK: consult https://github.com/minad/consult


### PR DESCRIPTION
This fixes #1.

The problem was using:

```org
#+TARGET: doom https://github.com/doomemacs/
```

instead of:


```org
#+LINK: doom https://github.com/doomemacs/
```
